### PR TITLE
docs(readme): publish volunteer ready README with setup and repo skel…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,133 @@
 # CiviCue
-CiviCu.io is a civic accountability platform surfacing evidence-based flashpoints when local government actions don't align with promises or outcomes.
+
+Evidence-based local accountability in under 90 seconds.
+
+CiviCue helps residents, journalists, and advocates see what is broken, why it matters, and who is responsible in their district. No endless PDFs. No guesswork. Clear accountability.
+
+## Why this matters
+
+Local government feels confusing. Many people do not know their supervisor or council member. Meeting minutes sit in PDFs. Votes lack context. The why behind outcomes often lives inside committees.
+
+CiviCue addresses this directionality problem with flashpoints - evidence-backed signposts that trigger only when promises, votes, and outcomes do not align.
+
+## Current status, September 2025
+
+### What is built
+
+- Supervisor voting records, 2018 to 2025, normalized into one schema
+- Supervisor to district mappings
+- JSON pipelines archiving local datasets
+- Crime incidents
+- 311 service calls
+- Evictions
+- Housing pipeline and completions
+- Committee meetings, minutes under tabulation
+
+### What is drafted
+
+- Flashpoint rules engine with three tiers
+- Tier 1: legislative behavior, votes, absences, delays
+- Tier 2: platform contradictions, campaign versus action
+- Tier 3: district outcomes, crime spikes, eviction surges, housing failures
+- Golden test cases, for example Engardio housing contradictions, ready for validation
+
+## Tech stack
+
+- **Backend**: Python for ETL and scrapers, PostgreSQL for schema, Google Apps Script for scheduled imports
+- **Storage**: Google Drive JSON exports, S3-compatible object storage planned
+- **Frontend**: React and D3 visualizations planned
+- **Integrity**: SHA-256 hashing of source documents, immutable evidence storage
+
+## How to help
+
+We welcome contributions of all sizes. Current needs:
+
+### Data and scraping
+
+- Parse and normalize committee minutes PDFs into structured JSON
+- Clean and dedupe large JSON archives: crime, 311, evictions
+
+### UX and frontend
+
+- Prototype district dashboards in React and D3
+- Design flows for fast clarity for residents and deeper paths for power users
+
+### Data modeling
+
+- Expand flashpoint rules
+- Validate golden tests on live SF and Detroit data
+
+## Getting started
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/civicue/civicue.git
+cd civicue
+pip install -r requirements.txt
+```
+
+Load the schema:
+
+```bash
+psql -f schema.sql
+```
+
+Run a sample ETL:
+
+```bash
+python etl_pipeline.py
+```
+
+## Good first issues
+
+- Parser for a sample committee minutes PDF to JSON
+- React component for a 90-second flashpoint view
+- Validate the Engardio housing contradiction test case
+- Normalization script for eviction dataset JSONs
+
+## Principles
+
+- **Nonpartisan**: no labels, no endorsements
+- **Evidence-based**: multiple independent receipts per flashpoint
+- **Transparent**: all sources hashed and verifiable
+- **Usable**: residents reach clarity in 90 seconds, power users go deeper
+
+## Repo skeleton
+
+```
+civicue/
+├── README.md
+├── schema.sql
+├── requirements.txt
+├── .env.example
+├── server/
+│   ├── api.py
+│   ├── etl_pipeline.py
+│   ├── detect_flashpoints.py
+│   ├── storage_config.yaml
+│   └── flashpoint_rules.yaml
+├── tests/
+│   └── test_golden_cases.py
+├── datasets/
+│   └── samples/
+│       ├── committee_minutes_sample.pdf
+│       ├── votes_sample.json
+│       └── evictions_sample.json
+├── docs/
+│   ├── methodology.txt
+│   └── governance.txt
+└── .github/
+    ├── ISSUE_TEMPLATE/
+    │   ├── module_task.md
+    │   └── good_first_issue.md
+    ├── pull_request_template.md
+    └── workflows/
+        └── ci.yml
+```
+
+## Contact
+
+**Project lead**: Byron Eppler  
+**Slack**: Beppler on SF CivicTech 
+**Email**: byron@civicue.io


### PR DESCRIPTION
…eton

Why
Publish a volunteer ready README.
What
	•	Add problem framing and flashpoint definition
	•	Add setup steps and schema load commands
	•	Add repo skeleton and contribution paths
	•	List four good first issues
	•	Invite Slack outreach and weekly triage
Risk
Docs only. No code paths changed.
Next
Add CONTRIBUTING.md, PR template, and issue templates.